### PR TITLE
Develop synt data amount UI

### DIFF
--- a/frontend/src/lib/features/prototypes/components/CreatePrototype.tsx
+++ b/frontend/src/lib/features/prototypes/components/CreatePrototype.tsx
@@ -49,6 +49,7 @@ export const CreatePrototype: React.FC = () => {
     const [generationError, setGenerationError] = useState<string | null>(null);
     const [useAuthentication, setUseAuthentication] = useState(true);
     const [useSyntheticData, setUseSyntheticData] = useState(false); // New state for Synthetic Data
+    const [syntheticCounts, setSyntheticCounts] = useState<Record<string, number>>({}); //extra
     const [databaseHash, setDatabaseHash] = useState<string | null>(null);
     const [databasePrototypes, setDatabasePrototypes] = useState([]);
     const [selectedDatabasePrototype, setSelectedDatabasePrototype] = useState(null);
@@ -140,6 +141,7 @@ export const CreatePrototype: React.FC = () => {
             "interfaces": selectedInterfaces,
             "useAuthentication": useAuthentication,
             "useSyntheticData": useSyntheticData,
+            "syntheticCounts": syntheticCounts,
         };
 
         const alphanumericRegex = /^[a-zA-Z0-9]+$/;
@@ -180,6 +182,26 @@ export const CreatePrototype: React.FC = () => {
             </Modal>
         );
     }
+
+    const hasName = (obj: any): obj is { name: string } => {
+        return obj && typeof obj.name === 'string';
+    };
+
+    const extractNodeNames = (node: any) => {
+        // Loop through all properties of the node (cls, enum, etc.)
+        const subObjectWithName = Object.values(node).find((sub) => hasName(sub));
+
+        return subObjectWithName ? subObjectWithName.name : null;
+    };
+
+
+    // Update synthetic data counts
+    const updateValue = (name: string, value: number) => {
+        setSyntheticCounts((prev) => ({
+            ...prev,
+            [name]: value, // Update the value for the specified name
+        }));
+    };
 
     return (
         <Modal open={open} onClose={() => { close(); setGenerationError(null) }}>
@@ -257,6 +279,39 @@ export const CreatePrototype: React.FC = () => {
                             <FormLabel sx={{ marginTop: '4px' }}>Use Synthetic Data</FormLabel>
                         </span>
                     </FormControl>
+
+                    {useSyntheticData && (
+                        <div className="mt-4">
+                            <h4 className="font-semibold mb-2">Specicfy Synthetic Data Amount Per Table</h4>
+                            {diagrams?.nodes?.map((node, index) => {
+                                // Find the first property with a `name`
+                                const name = extractNodeNames(node);
+
+                                if (!name) return null; // Skip if no name property is found
+
+                                return (
+                                    <div key={index} className="mb-4">
+                                        <label className="block font-medium mb-1">{name}</label>
+                                        <input
+                                            type="number"
+                                            value={syntheticCounts[name] || 0} // Default to 0 if no value set
+                                            onChange={(e) => updateValue(name, parseInt(e.target.value, 10))}
+                                            className="border border-gray-300 rounded px-2 py-1 w-32"
+                                            placeholder="Enter amount"
+                                        />
+                                    </div>
+                                );
+                            })}
+                        </div>
+                    )}
+
+
+                    {/* Optionally display diagrams directly in the UI */}
+                    <div className="mt-4">
+                        <h4 className="font-semibold">Diagrams Data (Debugging)</h4>
+                        <pre>{JSON.stringify(diagrams, null, 2)}</pre> {/* Display diagrams as formatted JSON */}
+                    </div>
+
                 </form>
                 <Divider />
                 <div className="flex flex-row pt-1">

--- a/frontend/src/lib/features/prototypes/components/CreatePrototype.tsx
+++ b/frontend/src/lib/features/prototypes/components/CreatePrototype.tsx
@@ -203,6 +203,10 @@ export const CreatePrototype: React.FC = () => {
         }));
     };
 
+    const validClassNames =
+        interfaces[0]?.data?.sections?.map((section) => section.class) || [];
+
+
     return (
         <Modal open={open} onClose={() => { close(); setGenerationError(null) }}>
             <ModalDialog>
@@ -222,7 +226,8 @@ export const CreatePrototype: React.FC = () => {
                 <Divider />
                 <form
                     id="create-project"
-                    className="flex min-w-96 flex-col gap-2"
+                    // className="flex min-w-96 flex-col gap-2"
+                    className="max-h-[400px] overflow-y-auto pr-2"
                     onSubmit={onSubmit}
                 >
                     <FormControl required>
@@ -250,6 +255,14 @@ export const CreatePrototype: React.FC = () => {
                             value={selectedInterfaces}
                             onChange={(newValue) => setSelectedInterfaces(newValue ? newValue.map((v) => v.value) : [])}
                         />
+
+                        {/* <pre className="max-h-[400px] overflow-y-auto pr-2 bg-gray-100 p-2 rounded text-sm">
+                            {JSON.stringify(
+                                interfaces[0]?.data?.sections?.map((section) => section.class),
+                                null,
+                                2
+                            )}
+                        </pre> */}
 
                     </FormControl>
                     <FormControl>
@@ -284,52 +297,58 @@ export const CreatePrototype: React.FC = () => {
                         <div className="mt-4">
                             <h4 className="font-semibold mb-2">Specify Synthetic Data Amount Per Node:</h4>
 
+                            {/* <pre className="max-h-[400px] overflow-y-auto pr-2 bg-gray-100 p-2 rounded text-sm">
+                                {JSON.stringify(
+                                    diagrams[0]?.nodes?.map((node) => node.cls_ptr),
+                                    null,
+                                    2
+                                )}
+                            </pre> */}
+                            {/* 
+                            <pre className="max-h-[400px] overflow-y-auto pr-2 bg-gray-100 p-2 rounded text-sm">
+                                {JSON.stringify(
+                                    diagrams[0],
+                                    null,
+                                    2
+                                )}
+                            </pre> */}
+
                             {/* Scrollable content */}
                             <div className="max-h-[400px] overflow-y-auto pr-2">
-                                {Array.isArray(diagrams) && diagrams.length > 0 ? (
-                                    <div className="mb-6 border p-4 rounded shadow">
-                                        {/* Access only the first diagram */}
-                                        {Array.isArray(diagrams[0].nodes) ? (
-                                            diagrams[0].nodes.map((node, nodeIndex) => {
-                                                const name = extractNodeNames(node);
+                                <div className="mb-6 border p-4 rounded shadow">
+                                    {diagrams[0].nodes
+                                        .filter((node) => validClassNames.includes(node.cls_ptr))
+                                        .map((node, index) => {
+                                            const name = extractNodeNames(node);
 
-                                                return (
-                                                    <div key={nodeIndex} className="mb-4">
-                                                        <h4 className="font-semibold mb-2">
-                                                            Node {nodeIndex + 1}: {name || " No name extracted"}
-                                                        </h4>
+                                            return (
+                                                <div key={index} className="mb-4">
+                                                    <h4 className="font-semibold mb-2">
+                                                        Node {index + 1}: {name}
+                                                    </h4>
 
-                                                        {name && (
-                                                            <input
-                                                                type="number"
-                                                                min="0"
-                                                                value={syntheticCounts[name] || 0}
-                                                                onChange={(e) => {
-                                                                    const newValue = parseInt(e.target.value, 10);
-                                                                    if (!isNaN(newValue) && newValue >= 0) {
-                                                                        updateValue(name, newValue);
-                                                                    }
-                                                                }}
-                                                                className="border border-gray-300 rounded px-2 py-1 w-32 mt-1"
-                                                                placeholder="Enter amount"
-                                                            />
-                                                        )}
-                                                    </div>
-                                                );
-                                            })
-                                        ) : (
-                                            <p className="text-red-500">No nodes found in the first diagram</p>
-                                        )}
-                                    </div>
-                                ) : (
-                                    <p className="text-red-500">No diagrams available</p>
-                                )}
+                                                    {name && (
+                                                        <input
+                                                            type="number"
+                                                            min="0"
+                                                            value={syntheticCounts[name] || 0}
+                                                            onChange={(e) => {
+                                                                const newValue = parseInt(e.target.value, 10);
+                                                                if (!isNaN(newValue) && newValue >= 0) {
+                                                                    updateValue(name, newValue);
+                                                                }
+                                                            }}
+                                                            className="border border-gray-300 rounded px-2 py-1 w-32 mt-1"
+                                                            placeholder="Enter amount"
+                                                        />
+                                                    )}
+                                                </div>
+                                            );
+                                        })}
+                                </div>
                             </div>
-
-                            <h4 className="font-semibold mt-4 mb-2">Done Rendering First Diagram</h4>
                         </div>
                     )}
-
 
                 </form>
                 <Divider />

--- a/frontend/src/lib/features/prototypes/components/CreatePrototype.tsx
+++ b/frontend/src/lib/features/prototypes/components/CreatePrototype.tsx
@@ -282,35 +282,54 @@ export const CreatePrototype: React.FC = () => {
 
                     {useSyntheticData && (
                         <div className="mt-4">
-                            <h4 className="font-semibold mb-2">Specicfy Synthetic Data Amount Per Table</h4>
-                            {diagrams?.nodes?.map((node, index) => {
-                                // Find the first property with a `name`
-                                const name = extractNodeNames(node);
+                            <h4 className="font-semibold mb-2">Specify Synthetic Data Amount Per Node:</h4>
 
-                                if (!name) return null; // Skip if no name property is found
+                            {/* Scrollable content */}
+                            <div className="max-h-[400px] overflow-y-auto pr-2">
+                                {Array.isArray(diagrams) && diagrams.length > 0 ? (
+                                    <div className="mb-6 border p-4 rounded shadow">
+                                        {/* Access only the first diagram */}
+                                        {Array.isArray(diagrams[0].nodes) ? (
+                                            diagrams[0].nodes.map((node, nodeIndex) => {
+                                                const name = extractNodeNames(node);
 
-                                return (
-                                    <div key={index} className="mb-4">
-                                        <label className="block font-medium mb-1">{name}</label>
-                                        <input
-                                            type="number"
-                                            value={syntheticCounts[name] || 0} // Default to 0 if no value set
-                                            onChange={(e) => updateValue(name, parseInt(e.target.value, 10))}
-                                            className="border border-gray-300 rounded px-2 py-1 w-32"
-                                            placeholder="Enter amount"
-                                        />
+                                                return (
+                                                    <div key={nodeIndex} className="mb-4">
+                                                        <h4 className="font-semibold mb-2">
+                                                            Node {nodeIndex + 1}: {name || " No name extracted"}
+                                                        </h4>
+
+                                                        {name && (
+                                                            <input
+                                                                type="number"
+                                                                min="0"
+                                                                value={syntheticCounts[name] || 0}
+                                                                onChange={(e) => {
+                                                                    const newValue = parseInt(e.target.value, 10);
+                                                                    if (!isNaN(newValue) && newValue >= 0) {
+                                                                        updateValue(name, newValue);
+                                                                    }
+                                                                }}
+                                                                className="border border-gray-300 rounded px-2 py-1 w-32 mt-1"
+                                                                placeholder="Enter amount"
+                                                            />
+                                                        )}
+                                                    </div>
+                                                );
+                                            })
+                                        ) : (
+                                            <p className="text-red-500">No nodes found in the first diagram</p>
+                                        )}
                                     </div>
-                                );
-                            })}
+                                ) : (
+                                    <p className="text-red-500">No diagrams available</p>
+                                )}
+                            </div>
+
+                            <h4 className="font-semibold mt-4 mb-2">Done Rendering First Diagram</h4>
                         </div>
                     )}
 
-
-                    {/* Optionally display diagrams directly in the UI */}
-                    <div className="mt-4">
-                        <h4 className="font-semibold">Diagrams Data (Debugging)</h4>
-                        <pre>{JSON.stringify(diagrams, null, 2)}</pre> {/* Display diagrams as formatted JSON */}
-                    </div>
 
                 </form>
                 <Divider />

--- a/frontend/src/lib/features/prototypes/components/CreatePrototype.tsx
+++ b/frontend/src/lib/features/prototypes/components/CreatePrototype.tsx
@@ -20,7 +20,7 @@ import { useAtom } from "jotai";
 import React, { useEffect, useState } from "react";
 import { useParams } from "react-router";
 import Select from "react-select";
- 
+
 type PrototypeInput = {
     name: string;
     description?: string;
@@ -29,7 +29,7 @@ type PrototypeInput = {
     metadata: Record<string, any>;
     database_hash?: string;
 };
- 
+
 type PrototypeOutput = {
     id: string;
     name: string;
@@ -37,7 +37,7 @@ type PrototypeOutput = {
     system: string;
     running: boolean;
 };
- 
+
 export const CreatePrototype: React.FC = () => {
     const [open, setOpen] = useAtom(createPrototypeAtom);
     const close = () => setOpen(false);
@@ -55,13 +55,13 @@ export const CreatePrototype: React.FC = () => {
     const [databaseHash, setDatabaseHash] = useState<string | null>(null);
     const [databasePrototypes, setDatabasePrototypes] = useState([]);
     const [selectedDatabasePrototype, setSelectedDatabasePrototype] = useState(null);
- 
+
     useEffect(() => {
         if (isSuccessInterfaces && interfaces) {
             setSelectedInterfaces(interfaces.map((e) => ({ label: e.name, value: e })));
         }
     }, [interfaces, isSuccessInterfaces]);
- 
+
     useEffect(() => {
         const computeHash = async () => {
             if (systemId && isSuccessInterfaces) {
@@ -69,17 +69,17 @@ export const CreatePrototype: React.FC = () => {
                     authAxios.get(`v1/metadata/systems/${systemId}/classes/`),
                     authAxios.get(`v1/metadata/systems/${systemId}/classifier-relations/`),
                 ]);
- 
+
                 const interfaceNames = interfaces.map((e) => ({ name: e.name }));
                 const inputString = `${systemId}${JSON.stringify(classifiers.data)}${JSON.stringify(relations.data)}${JSON.stringify(interfaceNames)}`;
                 const hash = CryptoJS.SHA256(inputString).toString(CryptoJS.enc.Hex);
                 setDatabaseHash(hash);
             }
         };
- 
+
         computeHash();
     }, [systemId, interfaces, isSuccessInterfaces]);
- 
+
     useEffect(() => {
         const fetchDatabasePrototypes = async () => {
             if (databaseHash) {
@@ -91,10 +91,10 @@ export const CreatePrototype: React.FC = () => {
                 }
             }
         };
- 
+
         fetchDatabasePrototypes();
     }, [databaseHash]);
- 
+
     const { mutateAsync, isPending } = useMutation<
         PrototypeOutput,
         unknown,
@@ -122,18 +122,18 @@ export const CreatePrototype: React.FC = () => {
                 });
                 return data
             }
- 
+
         },
         onError: (error) => {
             setGenerationError("An error occurred while creating the prototype!");
         },
     });
- 
+
     const queryClient = useQueryClient();
     const onSubmit: React.FormEventHandler<HTMLFormElement> = async (e) => {
         e.preventDefault();
         setError(null);
- 
+
         const formData = new FormData(e.currentTarget);
         const name = `${formData.get("name")}`.trim();
         const description = `${formData.get("description")}`;
@@ -146,18 +146,18 @@ export const CreatePrototype: React.FC = () => {
             "syntheticCounts": syntheticCounts,
             "syntheticInstructions": syntheticInstructions,
         };
- 
+
         const alphanumericRegex = /^[a-zA-Z0-9]+$/;
         if (!alphanumericRegex.test(name)) {
             setError("Name may only contain alphanumeric characters!");
             return;
         }
- 
+
         if (!databaseHash) {
             setError("No database hash.");
             return;
         }
- 
+
         mutateAsync({
             name,
             description,
@@ -172,7 +172,7 @@ export const CreatePrototype: React.FC = () => {
             console.log(err)
         });
     };
- 
+
     if (isPending) {
         return (
             <Modal open>
@@ -185,19 +185,19 @@ export const CreatePrototype: React.FC = () => {
             </Modal>
         );
     }
- 
+
     const hasName = (obj: any): obj is { name: string } => {
         return obj && typeof obj.name === 'string';
     };
- 
+
     const extractNodeNames = (node: any) => {
         // Loop through all properties of the node (cls, enum, etc.)
         const subObjectWithName = Object.values(node).find((sub) => hasName(sub));
- 
+
         return subObjectWithName ? subObjectWithName.name : null;
     };
- 
- 
+
+
     // Update synthetic data counts
     const updateValue = (name: string, value: number) => {
         setSyntheticCounts((prev) => ({
@@ -205,9 +205,11 @@ export const CreatePrototype: React.FC = () => {
             [name]: value, // Update the value for the specified name
         }));
     };
- 
+
     const validClassNames =
         interfaces[0]?.data?.sections?.map((section) => section.class) || [];
+
+
     return (
         <>
             <Modal open={open} onClose={() => { close(); setGenerationError(null) }}>
@@ -302,66 +304,76 @@ export const CreatePrototype: React.FC = () => {
                     )}
                 </ModalDialog>
             </Modal>
- 
+
             {/* Synthetic Data Popup Modal */}
             <Modal open={showSyntheticModal} onClose={() => setShowSyntheticModal(false)}>
                 <ModalDialog>
                     <Typography level="h4">Specify Synthetic Data Amount Per Node</Typography>
- 
-                    {/*Custom instructions for synthetic data generation*/}
-                    <FormControl className="mt-4">
-                        <FormLabel>Custom Instructions</FormLabel>
-                        <Input
-                            placeholder="e.g., 10 samples per user with real names"
-                            value={syntheticInstructions}
-                            onChange={(e) => setSyntheticInstructions(e.target.value)}
-                        />
-                    </FormControl>
- 
-                    <div className="max-h-[400px] overflow-y-auto pr-2 mt-2">
-                        <div className="mb-6 border p-4 rounded shadow">
-                            {isSuccessInterfaces && interfaces.length === 0 ? ( // warns user that they forgot to add interfaces
-                                <Typography sx={{ marginTop: '4px', marginBottom: '8px' }}>
-                                    <span className="text-sm text-orange-600">
-                                        No interfaces found. Please define at least one interface for this system in order to proceed with synthetic data generation.
-                                    </span>
-                                </Typography>
-                            ) : (
-                                diagrams[0]?.nodes
-                                    ?.filter((node) => validClassNames.includes(node.cls_ptr))
-                                    .map((node, index) => {
-                                        const name = extractNodeNames(node);
-                                        return (
-                                            <div key={index} className="mb-4">
-                                                <h4 className="font-semibold mb-2">Node {index + 1}: {name}</h4>
-                                                {name && (
-                                                    <input
-                                                        type="number"
-                                                        min="0"
-                                                        value={syntheticCounts[name] || 0}
-                                                        onChange={(e) => {
-                                                            const newValue = parseInt(e.target.value, 10);
-                                                            if (!isNaN(newValue) && newValue >= 0) {
-                                                                updateValue(name, newValue);
-                                                            }
-                                                        }}
-                                                        className="border border-gray-300 rounded px-2 py-1 w-32 mt-1"
-                                                        placeholder="Enter amount"
-                                                    />
-                                                )}
-                                            </div>
-                                        );
-                                    })
-                            )}
-                        </div>
-                    </div>
+                    {!interfaces[0]?.data?.pages?.sections || interfaces[0]?.data?.pages?.sections.length === 0 ? (
+                        <Typography sx={{ marginTop: '4px', marginBottom: '8px' }}>
+                            <span className="text-sm text-orange-600">
+                                No section components found in pages. Please define at least one section component for this system in order to proceed with synthetic data generation.
+                            </span>
+                        </Typography>
+                    ) : (
+                        <>
+                            {/*Custom instructions for synthetic data generation*/}
+                            <FormControl className="mt-4">
+                                <FormLabel>Custom Instructions</FormLabel>
+                                <Input
+                                    placeholder="e.g., 10 samples per user with real names"
+                                    value={syntheticInstructions}
+                                    onChange={(e) => setSyntheticInstructions(e.target.value)}
+                                />
+                            </FormControl>
+
+                            <div className="max-h-[400px] overflow-y-auto pr-2 mt-2">
+                                <div className="mb-6 border p-4 rounded shadow">
+                                    {!interfaces[0]?.data?.pages?.sections || interfaces[0]?.data?.pages?.sections.length === 0 ? ( // warns user that they forgot to add interfaces
+                                        <Typography sx={{ marginTop: '4px', marginBottom: '8px' }}>
+                                            <span className="text-sm text-orange-600">
+                                                No section components found in pages. Please define at least one section component for this system in order to proceed with synthetic data generation.
+                                            </span>
+                                        </Typography>
+                                    ) : (
+                                        diagrams[0]?.nodes
+                                            ?.filter((node) => validClassNames.includes(node.cls_ptr))
+                                            .map((node, index) => {
+                                                const name = extractNodeNames(node);
+                                                return (
+                                                    <div key={index} className="mb-4">
+                                                        <h4 className="font-semibold mb-2">Node {index + 1}: {name}</h4>
+                                                        {name && (
+                                                            <input
+                                                                type="number"
+                                                                min="0"
+                                                                value={syntheticCounts[name] || 0}
+                                                                onChange={(e) => {
+                                                                    const newValue = parseInt(e.target.value, 10);
+                                                                    if (!isNaN(newValue) && newValue >= 0) {
+                                                                        updateValue(name, newValue);
+                                                                    }
+                                                                }}
+                                                                className="border border-gray-300 rounded px-2 py-1 w-32 mt-1"
+                                                                placeholder="Enter amount"
+                                                            />
+                                                        )}
+                                                    </div>
+                                                );
+                                            })
+                                    )}
+                                </div>
+                            </div>
+                        </>
+                    )}
                     <Button onClick={() => setShowSyntheticModal(false)}>Done</Button>
+
                 </ModalDialog>
             </Modal>
- 
- 
+
+
         </>
     );
 };
- 
+
 export default CreatePrototype;

--- a/frontend/src/lib/features/prototypes/components/CreatePrototype.tsx
+++ b/frontend/src/lib/features/prototypes/components/CreatePrototype.tsx
@@ -250,13 +250,23 @@ export const CreatePrototype: React.FC = () => {
         let isValid = true;
         let errorMessage = '';
 
+        const hasValidNodes = diagrams[0]?.nodes?.some(node =>
+            validClassNames.includes(node.cls_ptr)
+        );
+
+        if (!hasValidNodes) {
+            setUseSyntheticData(false);
+            setShowSyntheticModal(false);
+            return;
+        }
+
         rules.forEach(({ sourceName, targetName, rule }) => {
             const sourceCount = syntheticCounts[sourceName] ?? 0;
             const targetCount = syntheticCounts[targetName] ?? 0;
 
-            if (rule === 'le') { // One to mamny relation
+            if (rule === 'le') { // One to manny relation
                 if (targetCount !== 0 && sourceCount === 0) {
-                    errorMessage = `${targetName} must have one ${sourceName}`;
+                    errorMessage = `${sourceName} should have at least 1, due to one-to-many associoation with target ${targetName}`;
                     isValid = false;
                 }
 
@@ -267,16 +277,16 @@ export const CreatePrototype: React.FC = () => {
 
             } else if (rule === 'ge') { // many to one relation
                 if (targetCount === 0 && sourceCount !== 0) {
-                    errorMessage = `${targetName} must have one ${sourceName}`;
+                    errorMessage = `${targetName} should have at least 1, due to many-to-one associoation with source ${sourceName}`;
                     isValid = false;
                 }
 
-                else if (sourceCount < targetCount) { // One to one relation
+                else if (sourceCount < targetCount) {
                     errorMessage = `${sourceName} must be greater than or equal to ${targetName}`;
                     isValid = false;
                 }
 
-            } else if (rule === 'eq' && sourceCount !== targetCount) {
+            } else if (rule === 'eq' && sourceCount !== targetCount) { // One to one relation
                 isValid = false;
                 errorMessage = `${sourceName} must have the same count as ${targetName}`;
             }

--- a/frontend/src/lib/features/prototypes/components/CreatePrototype.tsx
+++ b/frontend/src/lib/features/prototypes/components/CreatePrototype.tsx
@@ -51,6 +51,7 @@ export const CreatePrototype: React.FC = () => {
     const [useSyntheticData, setUseSyntheticData] = useState(false); // New state for Synthetic Data
     const [syntheticCounts, setSyntheticCounts] = useState<Record<string, number>>({}); // state to store synthetic data counts
     const [showSyntheticModal, setShowSyntheticModal] = useState(false); // modal state
+    const [syntheticInstructions, setSyntheticInstructions] = useState<string>(''); // state to store custom instructions for synthetic data generation
     const [databaseHash, setDatabaseHash] = useState<string | null>(null);
     const [databasePrototypes, setDatabasePrototypes] = useState([]);
     const [selectedDatabasePrototype, setSelectedDatabasePrototype] = useState(null);
@@ -143,6 +144,7 @@ export const CreatePrototype: React.FC = () => {
             "useAuthentication": useAuthentication,
             "useSyntheticData": useSyntheticData,
             "syntheticCounts": syntheticCounts,
+            "syntheticInstructions": syntheticInstructions,
         };
  
         const alphanumericRegex = /^[a-zA-Z0-9]+$/;
@@ -206,148 +208,160 @@ export const CreatePrototype: React.FC = () => {
  
     const validClassNames =
         interfaces[0]?.data?.sections?.map((section) => section.class) || [];
-return (
-    <>
-        <Modal open={open} onClose={() => { close(); setGenerationError(null) }}>
-            <ModalDialog>
-                <div className="flex w-full flex-row justify-between pb-1">
-                    <div className="flex flex-col">
-                        <h1 className="font-bold">Generate Prototype</h1>
-                        <h3 className="text-sm">Generate a new prototype using current metadata</h3>
-                    </div>
-                    <ModalClose
-                        sx={{ position: "relative", top: 0, right: 0 }}
-                    />
-                </div>
-                <Divider />
-                <form
-                    id="create-project"
-                    className="max-h-[400px] overflow-y-auto pr-2"
-                    onSubmit={onSubmit}
-                >
-                    <FormControl required>
-                        <FormLabel>Name</FormLabel>
-                        <Input name="name" placeholder="Prototype" required />
-                        {error && (
-                            <Typography sx={{ margin: '2px' }}>
-                                <h1 className="text-sm text-red-400">{error}</h1>
-                            </Typography>
-                        )}
-                    </FormControl>
-                    <FormControl>
-                        <FormLabel>Description</FormLabel>
-                        <Input name="description" placeholder="A whole new world..." />
-                    </FormControl>
-                    <FormControl>
-                        <FormLabel>Interfaces</FormLabel>
-                        <Select
-                            isMulti
-                            name="interfaces"
-                            options={interfaces.map((e) => ({ label: e.name, value: e }))}
-                            value={selectedInterfaces}
-                            onChange={(newValue) => setSelectedInterfaces(newValue ? newValue.map((v) => v.value) : [])}
+    return (
+        <>
+            <Modal open={open} onClose={() => { close(); setGenerationError(null) }}>
+                <ModalDialog>
+                    <div className="flex w-full flex-row justify-between pb-1">
+                        <div className="flex flex-col">
+                            <h1 className="font-bold">Generate Prototype</h1>
+                            <h3 className="text-sm">Generate a new prototype using current metadata</h3>
+                        </div>
+                        <ModalClose
+                            sx={{ position: "relative", top: 0, right: 0 }}
                         />
-                    </FormControl>
-                    <FormControl>
-                        <FormLabel>Reuse database</FormLabel>
-                        <Select
-                            name="database"
-                            options={databasePrototypes}
-                            value={selectedDatabasePrototype}
-                            onChange={setSelectedDatabasePrototype}
-                        />
-                    </FormControl>
-                    <FormControl>
-                        <span className="flex flex-row items-center gap-2">
-                            <Switch
-                                defaultChecked={useAuthentication}
-                                onChange={(e) => setUseAuthentication(e.target.checked)}
-                            />
-                            <FormLabel sx={{ marginTop: '4px' }}>Use Authentication</FormLabel>
-                        </span>
-                    </FormControl>
-                    <FormControl>
-                    <div className="flex flex-col gap-1">
-                        <span className="flex flex-row items-center gap-2">
-                            <Switch
-                                checked={useSyntheticData}
-                                onChange={(e) => {
-                                    const checked = e.target.checked;
-                                    setUseSyntheticData(checked); // synthetic data generation button 
-                                    if (checked) setShowSyntheticModal(true); // opens the new window for synthetic data
-                                }}
-                            />
-                            <FormLabel sx={{ marginTop: '4px' }}>Use Synthetic Data</FormLabel>
-                        </span>
                     </div>
-                </FormControl>
-                </form>
-                <Divider />
-                <div className="flex flex-row pt-1">
-                    <Button form="create-project" type="submit" disabled={isPending}>
-                        {isPending ? (
-                            <div className="flex flex-row gap-2">
-                                <CircularProgress className="animate-spin" />
-                                <p>Generating</p>
-                            </div>
-                        ) : "Create"}
-                    </Button>
-                </div>
-                {generationError && (
-                    <Typography sx={{ margin: '2px' }}>
-                        <h1 className="text-lg text-red-800">{generationError}</h1>
-                    </Typography>
-                )}
-            </ModalDialog>
-        </Modal>
- 
-        {/* Synthetic Data Popup Modal */}
-        <Modal open={showSyntheticModal} onClose={() => setShowSyntheticModal(false)}>
-            <ModalDialog>
-              <Typography level="h4">Specify Synthetic Data Amount Per Node</Typography>
-                <div className="max-h-[400px] overflow-y-auto pr-2 mt-2">
-                    <div className="mb-6 border p-4 rounded shadow">
-                    {isSuccessInterfaces && interfaces.length === 0 ? ( // warns user that they forgot to add interfaces
-                        <Typography sx={{ marginTop: '4px', marginBottom: '8px' }}>
-                            <span className="text-sm text-orange-600">
-                                No interfaces found. Please define at least one interface for this system in order to proceed with synthetic data generation.
+                    <Divider />
+                    <form
+                        id="create-project"
+                        className="max-h-[400px] overflow-y-auto pr-2"
+                        onSubmit={onSubmit}
+                    >
+                        <FormControl required>
+                            <FormLabel>Name</FormLabel>
+                            <Input name="name" placeholder="Prototype" required />
+                            {error && (
+                                <Typography sx={{ margin: '2px' }}>
+                                    <h1 className="text-sm text-red-400">{error}</h1>
+                                </Typography>
+                            )}
+                        </FormControl>
+                        <FormControl>
+                            <FormLabel>Description</FormLabel>
+                            <Input name="description" placeholder="A whole new world..." />
+                        </FormControl>
+                        <FormControl>
+                            <FormLabel>Interfaces</FormLabel>
+                            <Select
+                                isMulti
+                                name="interfaces"
+                                options={interfaces.map((e) => ({ label: e.name, value: e }))}
+                                value={selectedInterfaces}
+                                onChange={(newValue) => setSelectedInterfaces(newValue ? newValue.map((v) => v.value) : [])}
+                            />
+                        </FormControl>
+                        <FormControl>
+                            <FormLabel>Reuse database</FormLabel>
+                            <Select
+                                name="database"
+                                options={databasePrototypes}
+                                value={selectedDatabasePrototype}
+                                onChange={setSelectedDatabasePrototype}
+                            />
+                        </FormControl>
+                        <FormControl>
+                            <span className="flex flex-row items-center gap-2">
+                                <Switch
+                                    defaultChecked={useAuthentication}
+                                    onChange={(e) => setUseAuthentication(e.target.checked)}
+                                />
+                                <FormLabel sx={{ marginTop: '4px' }}>Use Authentication</FormLabel>
                             </span>
+                        </FormControl>
+                        <FormControl>
+                            <div className="flex flex-col gap-1">
+                                <span className="flex flex-row items-center gap-2">
+                                    <Switch
+                                        checked={useSyntheticData}
+                                        onChange={(e) => {
+                                            const checked = e.target.checked;
+                                            setUseSyntheticData(checked); // synthetic data generation button 
+                                            if (checked) setShowSyntheticModal(true); // opens the new window for synthetic data
+                                        }}
+                                    />
+                                    <FormLabel sx={{ marginTop: '4px' }}>Use Synthetic Data</FormLabel>
+                                </span>
+                            </div>
+                        </FormControl>
+                    </form>
+                    <Divider />
+                    <div className="flex flex-row pt-1">
+                        <Button form="create-project" type="submit" disabled={isPending}>
+                            {isPending ? (
+                                <div className="flex flex-row gap-2">
+                                    <CircularProgress className="animate-spin" />
+                                    <p>Generating</p>
+                                </div>
+                            ) : "Create"}
+                        </Button>
+                    </div>
+                    {generationError && (
+                        <Typography sx={{ margin: '2px' }}>
+                            <h1 className="text-lg text-red-800">{generationError}</h1>
                         </Typography>
-                    ) : (
-                        diagrams[0]?.nodes
-                            ?.filter((node) => validClassNames.includes(node.cls_ptr))
-                            .map((node, index) => {
-                                const name = extractNodeNames(node);
-                                return (
-                                    <div key={index} className="mb-4">
-                                        <h4 className="font-semibold mb-2">Node {index + 1}: {name}</h4>
-                                        {name && (
-                                            <input
-                                                type="number"
-                                                min="0"
-                                                value={syntheticCounts[name] || 0}
-                                                onChange={(e) => {
-                                                    const newValue = parseInt(e.target.value, 10);
-                                                    if (!isNaN(newValue) && newValue >= 0) {
-                                                        updateValue(name, newValue);
-                                                    }
-                                                }}
-                                                className="border border-gray-300 rounded px-2 py-1 w-32 mt-1"
-                                                placeholder="Enter amount"
-                                            />
-                                        )}
-                                    </div>
-                                );
-                            })
                     )}
-                </div>
-            </div>
-            <Button onClick={() => setShowSyntheticModal(false)}>Done</Button>
-        </ModalDialog>
-    </Modal>
+                </ModalDialog>
+            </Modal>
+ 
+            {/* Synthetic Data Popup Modal */}
+            <Modal open={showSyntheticModal} onClose={() => setShowSyntheticModal(false)}>
+                <ModalDialog>
+                    <Typography level="h4">Specify Synthetic Data Amount Per Node</Typography>
+ 
+                    {/*Custom instructions for synthetic data generation*/}
+                    <FormControl className="mt-4">
+                        <FormLabel>Custom Instructions</FormLabel>
+                        <Input
+                            placeholder="e.g., 10 samples per user with real names"
+                            value={syntheticInstructions}
+                            onChange={(e) => setSyntheticInstructions(e.target.value)}
+                        />
+                    </FormControl>
+ 
+                    <div className="max-h-[400px] overflow-y-auto pr-2 mt-2">
+                        <div className="mb-6 border p-4 rounded shadow">
+                            {isSuccessInterfaces && interfaces.length === 0 ? ( // warns user that they forgot to add interfaces
+                                <Typography sx={{ marginTop: '4px', marginBottom: '8px' }}>
+                                    <span className="text-sm text-orange-600">
+                                        No interfaces found. Please define at least one interface for this system in order to proceed with synthetic data generation.
+                                    </span>
+                                </Typography>
+                            ) : (
+                                diagrams[0]?.nodes
+                                    ?.filter((node) => validClassNames.includes(node.cls_ptr))
+                                    .map((node, index) => {
+                                        const name = extractNodeNames(node);
+                                        return (
+                                            <div key={index} className="mb-4">
+                                                <h4 className="font-semibold mb-2">Node {index + 1}: {name}</h4>
+                                                {name && (
+                                                    <input
+                                                        type="number"
+                                                        min="0"
+                                                        value={syntheticCounts[name] || 0}
+                                                        onChange={(e) => {
+                                                            const newValue = parseInt(e.target.value, 10);
+                                                            if (!isNaN(newValue) && newValue >= 0) {
+                                                                updateValue(name, newValue);
+                                                            }
+                                                        }}
+                                                        className="border border-gray-300 rounded px-2 py-1 w-32 mt-1"
+                                                        placeholder="Enter amount"
+                                                    />
+                                                )}
+                                            </div>
+                                        );
+                                    })
+                            )}
+                        </div>
+                    </div>
+                    <Button onClick={() => setShowSyntheticModal(false)}>Done</Button>
+                </ModalDialog>
+            </Modal>
+ 
  
         </>
     );
 };
-
+ 
 export default CreatePrototype;

--- a/frontend/src/lib/features/prototypes/components/CreatePrototype.tsx
+++ b/frontend/src/lib/features/prototypes/components/CreatePrototype.tsx
@@ -206,8 +206,89 @@ export const CreatePrototype: React.FC = () => {
         }));
     };
 
-    const validClassNames =
-        interfaces[0]?.data?.sections?.map((section) => section.class) || [];
+    const validClassNames = interfaces[0]?.data?.sections?.map((section) => section.class) || [];
+
+    const getMultiplicityRules = (): {
+        sourceName: string;
+        targetName: string;
+        rule: 'le' | 'ge' | 'eq';
+    }[] => {
+        if (!diagrams?.[0]?.edges || !diagrams?.[0]?.nodes) return [];
+
+        const nodesById = Object.fromEntries(
+            diagrams[0].nodes.map(node => [node.id, extractNodeNames(node)])
+        );
+
+        return diagrams[0].edges
+            .filter(edge => edge.rel?.multiplicity)
+            .map(edge => {
+                const { multiplicity } = edge.rel;
+                const sourceName = nodesById[edge.source_ptr];
+                const targetName = nodesById[edge.target_ptr];
+
+                if (!sourceName || !targetName) return null;
+
+                const srcMult = multiplicity.source;
+                const tgtMult = multiplicity.target;
+
+                let rule: 'le' | 'ge' | 'eq' | null = null;
+                if (srcMult === "1" && tgtMult === "1") rule = 'eq';
+                else if (srcMult === "1" && tgtMult === "*") rule = 'le';
+                else if (srcMult === "*" && tgtMult === "1") rule = 'ge';
+
+                return rule ? { sourceName, targetName, rule } : null;
+            })
+            .filter(Boolean) as {
+                sourceName: string;
+                targetName: string;
+                rule: 'le' | 'ge' | 'eq';
+            }[];
+    };
+
+    const handleSyntheticValidation = () => {
+        const rules = getMultiplicityRules();
+        let isValid = true;
+        let errorMessage = '';
+
+        rules.forEach(({ sourceName, targetName, rule }) => {
+            const sourceCount = syntheticCounts[sourceName] ?? 0;
+            const targetCount = syntheticCounts[targetName] ?? 0;
+
+            if (rule === 'le') { // One to mamny relation
+                if (targetCount !== 0 && sourceCount === 0) {
+                    errorMessage = `${targetName} must have one ${sourceName}`;
+                    isValid = false;
+                }
+
+                else if (sourceCount > targetCount && targetCount !== 0) {
+                    errorMessage = `${sourceName} must be less than or equal to ${targetName}`;
+                    isValid = false;
+                }
+
+            } else if (rule === 'ge') { // many to one relation
+                if (targetCount === 0 && sourceCount !== 0) {
+                    errorMessage = `${targetName} must have one ${sourceName}`;
+                    isValid = false;
+                }
+
+                else if (sourceCount < targetCount) { // One to one relation
+                    errorMessage = `${sourceName} must be greater than or equal to ${targetName}`;
+                    isValid = false;
+                }
+
+            } else if (rule === 'eq' && sourceCount !== targetCount) {
+                isValid = false;
+                errorMessage = `${sourceName} must have the same count as ${targetName}`;
+            }
+        });
+
+        if (isValid) {
+            setGenerationError(null);
+            setShowSyntheticModal(false);
+        } else {
+            setGenerationError(errorMessage);
+        }
+    };
 
 
     return (
@@ -309,7 +390,12 @@ export const CreatePrototype: React.FC = () => {
             <Modal open={showSyntheticModal} onClose={() => setShowSyntheticModal(false)}>
                 <ModalDialog>
                     <Typography level="h4">Specify Synthetic Data Amount Per Node</Typography>
-                    {!interfaces[0]?.data?.pages?.sections || interfaces[0]?.data?.pages?.sections.length === 0 ? (
+                    {generationError && (
+                        <Typography sx={{ margin: '2px' }}>
+                            <h1 className="text-lg text-red-800">{generationError}</h1>
+                        </Typography>
+                    )}
+                    {!interfaces[0]?.data?.sections || interfaces[0]?.data?.sections.length === 0 ? (
                         <Typography sx={{ marginTop: '4px', marginBottom: '8px' }}>
                             <span className="text-sm text-orange-600">
                                 No section components found in pages. Please define at least one section component for this system in order to proceed with synthetic data generation.
@@ -329,15 +415,8 @@ export const CreatePrototype: React.FC = () => {
 
                             <div className="max-h-[400px] overflow-y-auto pr-2 mt-2">
                                 <div className="mb-6 border p-4 rounded shadow">
-                                    {!interfaces[0]?.data?.pages?.sections || interfaces[0]?.data?.pages?.sections.length === 0 ? ( // warns user that they forgot to add interfaces
-                                        <Typography sx={{ marginTop: '4px', marginBottom: '8px' }}>
-                                            <span className="text-sm text-orange-600">
-                                                No section components found in pages. Please define at least one section component for this system in order to proceed with synthetic data generation.
-                                            </span>
-                                        </Typography>
-                                    ) : (
-                                        diagrams[0]?.nodes
-                                            ?.filter((node) => validClassNames.includes(node.cls_ptr))
+                                    {
+                                        diagrams[0]?.nodes?.filter((node) => validClassNames.includes(node.cls_ptr))
                                             .map((node, index) => {
                                                 const name = extractNodeNames(node);
                                                 return (
@@ -361,12 +440,12 @@ export const CreatePrototype: React.FC = () => {
                                                     </div>
                                                 );
                                             })
-                                    )}
+                                    }
                                 </div>
                             </div>
                         </>
                     )}
-                    <Button onClick={() => setShowSyntheticModal(false)}>Done</Button>
+                    <Button onClick={handleSyntheticValidation}>Done</Button>
 
                 </ModalDialog>
             </Modal>

--- a/frontend/src/lib/features/prototypes/components/CreatePrototype.tsx
+++ b/frontend/src/lib/features/prototypes/components/CreatePrototype.tsx
@@ -20,7 +20,7 @@ import { useAtom } from "jotai";
 import React, { useEffect, useState } from "react";
 import { useParams } from "react-router";
 import Select from "react-select";
-
+ 
 type PrototypeInput = {
     name: string;
     description?: string;
@@ -29,7 +29,7 @@ type PrototypeInput = {
     metadata: Record<string, any>;
     database_hash?: string;
 };
-
+ 
 type PrototypeOutput = {
     id: string;
     name: string;
@@ -37,7 +37,7 @@ type PrototypeOutput = {
     system: string;
     running: boolean;
 };
-
+ 
 export const CreatePrototype: React.FC = () => {
     const [open, setOpen] = useAtom(createPrototypeAtom);
     const close = () => setOpen(false);
@@ -49,17 +49,18 @@ export const CreatePrototype: React.FC = () => {
     const [generationError, setGenerationError] = useState<string | null>(null);
     const [useAuthentication, setUseAuthentication] = useState(true);
     const [useSyntheticData, setUseSyntheticData] = useState(false); // New state for Synthetic Data
-    const [syntheticCounts, setSyntheticCounts] = useState<Record<string, number>>({}); //extra
+    const [syntheticCounts, setSyntheticCounts] = useState<Record<string, number>>({}); // state to store synthetic data counts
+    const [showSyntheticModal, setShowSyntheticModal] = useState(false); // modal state
     const [databaseHash, setDatabaseHash] = useState<string | null>(null);
     const [databasePrototypes, setDatabasePrototypes] = useState([]);
     const [selectedDatabasePrototype, setSelectedDatabasePrototype] = useState(null);
-
+ 
     useEffect(() => {
         if (isSuccessInterfaces && interfaces) {
             setSelectedInterfaces(interfaces.map((e) => ({ label: e.name, value: e })));
         }
     }, [interfaces, isSuccessInterfaces]);
-
+ 
     useEffect(() => {
         const computeHash = async () => {
             if (systemId && isSuccessInterfaces) {
@@ -67,17 +68,17 @@ export const CreatePrototype: React.FC = () => {
                     authAxios.get(`v1/metadata/systems/${systemId}/classes/`),
                     authAxios.get(`v1/metadata/systems/${systemId}/classifier-relations/`),
                 ]);
-
+ 
                 const interfaceNames = interfaces.map((e) => ({ name: e.name }));
                 const inputString = `${systemId}${JSON.stringify(classifiers.data)}${JSON.stringify(relations.data)}${JSON.stringify(interfaceNames)}`;
                 const hash = CryptoJS.SHA256(inputString).toString(CryptoJS.enc.Hex);
                 setDatabaseHash(hash);
             }
         };
-
+ 
         computeHash();
     }, [systemId, interfaces, isSuccessInterfaces]);
-
+ 
     useEffect(() => {
         const fetchDatabasePrototypes = async () => {
             if (databaseHash) {
@@ -89,10 +90,10 @@ export const CreatePrototype: React.FC = () => {
                 }
             }
         };
-
+ 
         fetchDatabasePrototypes();
     }, [databaseHash]);
-
+ 
     const { mutateAsync, isPending } = useMutation<
         PrototypeOutput,
         unknown,
@@ -120,18 +121,18 @@ export const CreatePrototype: React.FC = () => {
                 });
                 return data
             }
-
+ 
         },
         onError: (error) => {
             setGenerationError("An error occurred while creating the prototype!");
         },
     });
-
+ 
     const queryClient = useQueryClient();
     const onSubmit: React.FormEventHandler<HTMLFormElement> = async (e) => {
         e.preventDefault();
         setError(null);
-
+ 
         const formData = new FormData(e.currentTarget);
         const name = `${formData.get("name")}`.trim();
         const description = `${formData.get("description")}`;
@@ -143,18 +144,18 @@ export const CreatePrototype: React.FC = () => {
             "useSyntheticData": useSyntheticData,
             "syntheticCounts": syntheticCounts,
         };
-
+ 
         const alphanumericRegex = /^[a-zA-Z0-9]+$/;
         if (!alphanumericRegex.test(name)) {
             setError("Name may only contain alphanumeric characters!");
             return;
         }
-
+ 
         if (!databaseHash) {
             setError("No database hash.");
             return;
         }
-
+ 
         mutateAsync({
             name,
             description,
@@ -169,7 +170,7 @@ export const CreatePrototype: React.FC = () => {
             console.log(err)
         });
     };
-
+ 
     if (isPending) {
         return (
             <Modal open>
@@ -182,19 +183,19 @@ export const CreatePrototype: React.FC = () => {
             </Modal>
         );
     }
-
+ 
     const hasName = (obj: any): obj is { name: string } => {
         return obj && typeof obj.name === 'string';
     };
-
+ 
     const extractNodeNames = (node: any) => {
         // Loop through all properties of the node (cls, enum, etc.)
         const subObjectWithName = Object.values(node).find((sub) => hasName(sub));
-
+ 
         return subObjectWithName ? subObjectWithName.name : null;
     };
-
-
+ 
+ 
     // Update synthetic data counts
     const updateValue = (name: string, value: number) => {
         setSyntheticCounts((prev) => ({
@@ -202,12 +203,11 @@ export const CreatePrototype: React.FC = () => {
             [name]: value, // Update the value for the specified name
         }));
     };
-
+ 
     const validClassNames =
         interfaces[0]?.data?.sections?.map((section) => section.class) || [];
-
-
-    return (
+return (
+    <>
         <Modal open={open} onClose={() => { close(); setGenerationError(null) }}>
             <ModalDialog>
                 <div className="flex w-full flex-row justify-between pb-1">
@@ -216,17 +216,12 @@ export const CreatePrototype: React.FC = () => {
                         <h3 className="text-sm">Generate a new prototype using current metadata</h3>
                     </div>
                     <ModalClose
-                        sx={{
-                            position: "relative",
-                            top: 0,
-                            right: 0,
-                        }}
+                        sx={{ position: "relative", top: 0, right: 0 }}
                     />
                 </div>
                 <Divider />
                 <form
                     id="create-project"
-                    // className="flex min-w-96 flex-col gap-2"
                     className="max-h-[400px] overflow-y-auto pr-2"
                     onSubmit={onSubmit}
                 >
@@ -241,10 +236,7 @@ export const CreatePrototype: React.FC = () => {
                     </FormControl>
                     <FormControl>
                         <FormLabel>Description</FormLabel>
-                        <Input
-                            name="description"
-                            placeholder="A whole new world..."
-                        />
+                        <Input name="description" placeholder="A whole new world..." />
                     </FormControl>
                     <FormControl>
                         <FormLabel>Interfaces</FormLabel>
@@ -255,15 +247,6 @@ export const CreatePrototype: React.FC = () => {
                             value={selectedInterfaces}
                             onChange={(newValue) => setSelectedInterfaces(newValue ? newValue.map((v) => v.value) : [])}
                         />
-
-                        {/* <pre className="max-h-[400px] overflow-y-auto pr-2 bg-gray-100 p-2 rounded text-sm">
-                            {JSON.stringify(
-                                interfaces[0]?.data?.sections?.map((section) => section.class),
-                                null,
-                                2
-                            )}
-                        </pre> */}
-
                     </FormControl>
                     <FormControl>
                         <FormLabel>Reuse database</FormLabel>
@@ -284,81 +267,30 @@ export const CreatePrototype: React.FC = () => {
                         </span>
                     </FormControl>
                     <FormControl>
+                    <div className="flex flex-col gap-1">
                         <span className="flex flex-row items-center gap-2">
                             <Switch
                                 checked={useSyntheticData}
-                                onChange={(e) => setUseSyntheticData(e.target.checked)}  // synthetic data generation button 
+                                onChange={(e) => {
+                                    const checked = e.target.checked;
+                                    setUseSyntheticData(checked); // synthetic data generation button 
+                                    if (checked) setShowSyntheticModal(true); // opens the new window for synthetic data
+                                }}
                             />
                             <FormLabel sx={{ marginTop: '4px' }}>Use Synthetic Data</FormLabel>
                         </span>
-                    </FormControl>
-
-                    {useSyntheticData && (
-                        <div className="mt-4">
-                            <h4 className="font-semibold mb-2">Specify Synthetic Data Amount Per Node:</h4>
-
-                            {/* <pre className="max-h-[400px] overflow-y-auto pr-2 bg-gray-100 p-2 rounded text-sm">
-                                {JSON.stringify(
-                                    diagrams[0]?.nodes?.map((node) => node.cls_ptr),
-                                    null,
-                                    2
-                                )}
-                            </pre> */}
-                            {/* 
-                            <pre className="max-h-[400px] overflow-y-auto pr-2 bg-gray-100 p-2 rounded text-sm">
-                                {JSON.stringify(
-                                    diagrams[0],
-                                    null,
-                                    2
-                                )}
-                            </pre> */}
-
-                            {/* Scrollable content */}
-                            <div className="max-h-[400px] overflow-y-auto pr-2">
-                                <div className="mb-6 border p-4 rounded shadow">
-                                    {diagrams[0].nodes
-                                        .filter((node) => validClassNames.includes(node.cls_ptr))
-                                        .map((node, index) => {
-                                            const name = extractNodeNames(node);
-
-                                            return (
-                                                <div key={index} className="mb-4">
-                                                    <h4 className="font-semibold mb-2">
-                                                        Node {index + 1}: {name}
-                                                    </h4>
-
-                                                    {name && (
-                                                        <input
-                                                            type="number"
-                                                            min="0"
-                                                            value={syntheticCounts[name] || 0}
-                                                            onChange={(e) => {
-                                                                const newValue = parseInt(e.target.value, 10);
-                                                                if (!isNaN(newValue) && newValue >= 0) {
-                                                                    updateValue(name, newValue);
-                                                                }
-                                                            }}
-                                                            className="border border-gray-300 rounded px-2 py-1 w-32 mt-1"
-                                                            placeholder="Enter amount"
-                                                        />
-                                                    )}
-                                                </div>
-                                            );
-                                        })}
-                                </div>
-                            </div>
-                        </div>
-                    )}
-
+                    </div>
+                </FormControl>
                 </form>
                 <Divider />
                 <div className="flex flex-row pt-1">
                     <Button form="create-project" type="submit" disabled={isPending}>
-                        {isPending ?
+                        {isPending ? (
                             <div className="flex flex-row gap-2">
                                 <CircularProgress className="animate-spin" />
                                 <p>Generating</p>
-                            </div> : "Create"}
+                            </div>
+                        ) : "Create"}
                     </Button>
                 </div>
                 {generationError && (
@@ -368,6 +300,53 @@ export const CreatePrototype: React.FC = () => {
                 )}
             </ModalDialog>
         </Modal>
+ 
+        {/* Synthetic Data Popup Modal */}
+        <Modal open={showSyntheticModal} onClose={() => setShowSyntheticModal(false)}>
+            <ModalDialog>
+              <Typography level="h4">Specify Synthetic Data Amount Per Node</Typography>
+                <div className="max-h-[400px] overflow-y-auto pr-2 mt-2">
+                    <div className="mb-6 border p-4 rounded shadow">
+                    {isSuccessInterfaces && interfaces.length === 0 ? ( // warns user that they forgot to add interfaces
+                        <Typography sx={{ marginTop: '4px', marginBottom: '8px' }}>
+                            <span className="text-sm text-orange-600">
+                                No interfaces found. Please define at least one interface for this system in order to proceed with synthetic data generation.
+                            </span>
+                        </Typography>
+                    ) : (
+                        diagrams[0]?.nodes
+                            ?.filter((node) => validClassNames.includes(node.cls_ptr))
+                            .map((node, index) => {
+                                const name = extractNodeNames(node);
+                                return (
+                                    <div key={index} className="mb-4">
+                                        <h4 className="font-semibold mb-2">Node {index + 1}: {name}</h4>
+                                        {name && (
+                                            <input
+                                                type="number"
+                                                min="0"
+                                                value={syntheticCounts[name] || 0}
+                                                onChange={(e) => {
+                                                    const newValue = parseInt(e.target.value, 10);
+                                                    if (!isNaN(newValue) && newValue >= 0) {
+                                                        updateValue(name, newValue);
+                                                    }
+                                                }}
+                                                className="border border-gray-300 rounded px-2 py-1 w-32 mt-1"
+                                                placeholder="Enter amount"
+                                            />
+                                        )}
+                                    </div>
+                                );
+                            })
+                    )}
+                </div>
+            </div>
+            <Button onClick={() => setShowSyntheticModal(false)}>Done</Button>
+        </ModalDialog>
+    </Modal>
+ 
+        </>
     );
 };
 


### PR DESCRIPTION
###  Summary

This PR introduces several updates to improve the UI and data validation around synthetic data generation in the prototype editor.

---

###  Changes Included
- **Popup**: Opens a popup whenever the "Use Synthetic Data" toggle is switched to true.
- **Specify Synthetic Data Amount**: Users can specify the amount of synthetic data for each node when synthetic data is enabled.
- **Custom Instructions**: Users can specify custom instructions when synthetic data is enabled (toggle is true).
- **Auto-disable synthetic data toggle** when no valid nodes (with `cls_ptr` matching allowed types) are present in the diagram.
- **Enforce dependency constraints** to ensure synthetic data can only be enabled when valid section components are defined.
- **Prevent input of custom instructions and counts** if no section component is available — avoids confusion and invalid state.
- Finalized and styled the **synthetic data generation modal** with informative messaging.
- **Debug feature:** Outputs diagram JSON to the UI when synthetic data is enabled to assist with testing and verification.
- Minor fixes to prior commits and UI consistency improvements.
- Removed inputs related to nodes that will not be utilized by the prototype.

---

###  Testing & Validation

- Tested enabling/disabling of synthetic data toggle under various diagram conditions.
- Verified debug JSON output is shown only when appropriate.
- Confirmed modals and UI updates reflect the state of node availability accurately.
